### PR TITLE
Updates to Support GG Pinned Builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Pantheon AGCDN Management
+
+Enables self service management of specific AGCDN settings.
+
+The UI provides a way to do the following tasks:
+
+* Full Purge of AGCDN - This is for all domains and URLs attached to the site. Applicable for customers with Image Optimization
+
+* Search and Edit Dictionaries - With varying purpose and function, we create Dictionaries that lets customer maintain these keys and values. Usual use cases are Redirects, Geo-blocklist and so on
+
+* Search and Edit ACL Lists - ACL or Access Control Lists are lists of IP Addresses usually meant for Allowlist or Blocklist features.
+
+## How to Use
+
+### Installation
+
+* Install the Module on your site
+  * Installing only pantheon_agcdn_management will enable all functionality.
+  * Installing pantheon_agcdn_management_settings will enable only cache purging and management of the settings dictionary (intended for customers who are 'pinning' specific static build assets).
+* Add the Client Key provided by Pantheon Professional Services and Save
+  * Go to Configuration > AGCDN Management
+* Once the Client Key is detected and accepted, the rest of the UI unlocks
+  * Confirm the the Sections have been populated or does not show an error message
+
+### Usage
+* Select the proper dictionary or ACL name and click Edit
+* Proceed to Add, Edit or Delete the entries
+  * Note: Make sure to follow the relevant configuration and documentation on how these work

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pantheon-systems/pantheon_agcdn_management",
+    "name": "drupal/pantheon_agcdn_management",
     "type": "drupal-module",
     "description": "Manage AGCDN configurations",
     "keywords": [],

--- a/modules/pantheon_agcdn_management_settings/pantheon_agcdn_management_settings.info.yml
+++ b/modules/pantheon_agcdn_management_settings/pantheon_agcdn_management_settings.info.yml
@@ -1,0 +1,8 @@
+name: 'AGCDN Management Settings'
+type: module
+description: 'Manage only the AGCDN settings dictionary'
+core: 8.x
+core_version_requirement: ^8 || ^9
+package: 'Pantheon'
+dependencies:
+  - pantheon_agcdn_management:pantheon_agcdn_management

--- a/modules/pantheon_agcdn_management_settings/pantheon_agcdn_management_settings.module
+++ b/modules/pantheon_agcdn_management_settings/pantheon_agcdn_management_settings.module
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Contains pantheon_agcdn_management_settings.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function pantheon_agcdn_management_settings_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the pantheon_agcdn_management module.
+    case 'help.page.pantheon_agcdn_management_settings':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Manage only the AGCDN settings dictionary') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+/**
+ * Implements hook_page_attachments().
+ */
+function pantheon_agcdn_management_settings_page_attachments(&$attachments) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  if ($route_name === 'pantheon_agcdn_management.agcdn_settings_form') {
+    // Pass 'settings' submodule context to vue app.
+    $attachments['#attached']['drupalSettings']['pantheon_agcdn_management']['submodule'] = 'settings';
+  }
+}

--- a/pantheon_agcdn_management.info.yml
+++ b/pantheon_agcdn_management.info.yml
@@ -2,4 +2,5 @@ name: 'AGCDN Management'
 type: module
 description: 'Manage AGCDN configurations'
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Pantheon'

--- a/pantheon_agcdn_management.libraries.yml
+++ b/pantheon_agcdn_management.libraries.yml
@@ -5,7 +5,7 @@ vue:
 
 admin_app:
   js:
-    https://cdn.jsdelivr.net/gh/backlineint/vue-agcdn-mgmt@0c627821524000c0235766a4f5d99a0d7cd47116/dist/main.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/gh/pantheon-systems/vue-agcdn-mgmt@v0.9.6/dist/main.js: { type: external, minified: true }
   dependencies:
     - core/drupal
     - core/drupalSettings

--- a/pantheon_agcdn_management.libraries.yml
+++ b/pantheon_agcdn_management.libraries.yml
@@ -5,7 +5,7 @@ vue:
 
 admin_app:
   js:
-    https://cdn.jsdelivr.net/gh/backlineint/vue-agcdn-mgmt@pin-builds/dist/main.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/gh/backlineint/vue-agcdn-mgmt@0c627821524000c0235766a4f5d99a0d7cd47116/dist/main.js: { type: external, minified: true }
   dependencies:
     - core/drupal
     - core/drupalSettings

--- a/pantheon_agcdn_management.libraries.yml
+++ b/pantheon_agcdn_management.libraries.yml
@@ -5,7 +5,7 @@ vue:
 
 admin_app:
   js:
-    https://cdn.jsdelivr.net/gh/pantheon-systems/vue-agcdn-mgmt@v0.9/dist/main.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/gh/backlineint/vue-agcdn-mgmt@pin-builds/dist/main.js: { type: external, minified: true }
   dependencies:
     - core/drupal
     - core/drupalSettings

--- a/src/Form/AgcdnSettingsForm.php
+++ b/src/Form/AgcdnSettingsForm.php
@@ -6,7 +6,7 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Class AgcdnSettingsForm.
+ * Configuration form for AGCDN Settings.
  */
 class AgcdnSettingsForm extends ConfigFormBase {
 


### PR DESCRIPTION
Adds a pantheon_agcdn_management_settings submodule - enabling that module will enable the parent dependency, and restrict the embedded Vue app to only clearing the AGCDN cache and editing the settings dictionary. All of the settings dictionary probably still exposes a little more than we want, but that felt like a reasonable middle ground considering the timeline.

Nothing will prevent someone from disabling pantheon_agcdn_management_settings and getting access to all the functionality of this module. We'll have to be clear with the client that we intend that they use pantheon_agcdn_management_settings and are not supporting beyond that use case.

Local testing:
* Add the following entry to the repository section in the site's composer.json:
`        {
            "type": "vcs",
            "url": "https://github.com/backlineint/pantheon_agcdn_management.git"
        }`
* `composer require pantheon-systems/pantheon_agcdn_management`
* manually update the entry in composer.json to match: `"pantheon-systems/pantheon_agcdn_management": "dev-pinned-builds",`
* `composer update pantheon-systems/pantheon_agcdn_management`
* `lando drush en pantheon_agcdn_management_settings`
* Add the Client Key and Save - Go to Configuration > AGCDN Management

We'll eventually publish this on d.o so the `repository` and other composer magic won't be necessary.