### PR TITLE
Update to functioning CDN for Vue

### DIFF
--- a/pantheon_agcdn_management.libraries.yml
+++ b/pantheon_agcdn_management.libraries.yml
@@ -1,7 +1,7 @@
 vue:
   version: 2.6.12
   js:
-    https://vuejs.org/js/vue.js: { type: external, minified: false }
+    https://cdn.jsdelivr.net/npm/vue@2.6.12: { type: external, minified: false }
 
 admin_app:
   js:


### PR DESCRIPTION
The CDN update needs to be made for the vue library rather than the admin_app library.