### PR TITLE
Update AgcdnSettingsForm.php

### DIFF
--- a/src/Form/AgcdnSettingsForm.php
+++ b/src/Form/AgcdnSettingsForm.php
@@ -38,6 +38,13 @@ class AgcdnSettingsForm extends ConfigFormBase {
       '#maxlength' => 64,
       '#size' => 64,
       '#default_value' => $config->get('api_key'),
+      '#attributes' => ['id' => 'api-key-field'], // Add ID attribute to the textfield
+    ];
+    $form['api_key_label'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'label',
+      '#attributes' => ['for' => 'api-key-field'], // Use ID attribute of the textfield
+      '#value' => $this->t('API Key'), // Label text
     ];
     return parent::buildForm($form, $form_state);
   }


### PR DESCRIPTION
Attempt on fixing the "Incorrect use of <label for=FORM_ELEMENT>" issue in your Drupal form.

![image](https://github.com/pantheon-systems/pantheon_agcdn_management/assets/66335125/839e9862-0f58-45e3-a9ef-41b89894346d)

Reproduced from: https://dev-dlopez-d9headless.pantheonsite.io/admin/config/pantheon_agcdn_management/settings